### PR TITLE
use valid dependency tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "sort"
     ],
     "dependencies": {
-        "datatables.net-staterestore": ">=null",
+        "datatables.net-staterestore": ">=1.0.1",
         "datatables.net-bs4": ">=1.11.3",
         "jquery": ">=1.7"
     },


### PR DESCRIPTION
Untested but I assume it should fix #1 which prevents package installation on npm 8.3.0 (earlier versions untested).